### PR TITLE
Fix version number in HA

### DIFF
--- a/custom_components/expose_camera_stream_source/manifest.json
+++ b/custom_components/expose_camera_stream_source/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/felipecrs/hass-expose-camera-stream-source/issues",
-  "version": "0.1.4"
+  "version": "0.2.1"
 }


### PR DESCRIPTION
Version is still showing 0.1.4 in HA, this bumps up the manifest version to 0.2.1 so you can make a new release.

<img width="498" alt="image" src="https://github.com/user-attachments/assets/8144ba62-9b6a-49ec-a25d-56b802201fe5">
